### PR TITLE
Authorization headers while embedding openapi specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Usage of go-oas3:
   -path string
   -swagger-addr string
     	 (default "swagger.yaml")
+  -authorization string 
+    a list of comma-separated key:value pairs to be sent as headers alongside each http request
+
 ```
 ## Example
 Run with: ```go-oas3 -swagger-addr https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml -package example -path ./example```

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -2,8 +2,11 @@ package configurator
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/heetch/confita"
 	"github.com/heetch/confita/backend/flags"
@@ -16,12 +19,30 @@ type Config struct {
 
 	ComponentsPackage string `config:"componentsPackage"`
 	ComponentsPath    string `config:"componentsPath"`
+
+	Authorization string `config:"authorization,short=a,description=a list of comma-separated key:value pairs to be sent as headers alongside each http request"`
 }
 
 func (config *Config) Defaults() *Config {
 	config.SwaggerAddr = "swagger.yaml"
 
 	return config
+}
+
+func (config *Config) Headers() (http.Header, error) {
+	headers := strings.Split(config.Authorization, ",")
+	out := make(http.Header)
+
+	for _, header := range headers {
+		keyValue := strings.Split(header, ":")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("invalid header format: %q", header)
+		}
+
+		out[keyValue[0]] = []string{keyValue[1]}
+	}
+
+	return out, nil
 }
 
 type Configurator struct {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -23,7 +23,7 @@ func (loader *Loader) Load() (*openapi3.Swagger, error) {
 			return nil, err
 		}
 
-		setTransportWithHeaders(headers)
+		loader.setTransportWithHeaders(headers)
 	}
 
 	u, err := url.Parse(loader.config.SwaggerAddr)
@@ -44,7 +44,7 @@ func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 	return fn(req)
 }
 
-func setTransportWithHeaders(headers http.Header) {
+func (loader Loader) setTransportWithHeaders(headers http.Header) {
 	http.DefaultClient.Transport = RoundTripperFunc(func(request *http.Request) (*http.Response, error) {
 		for key, value := range headers {
 			request.Header[key] = value

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -16,6 +17,15 @@ func (loader *Loader) Load() (*openapi3.Swagger, error) {
 	swaggerLoader := openapi3.NewSwaggerLoader()
 	swaggerLoader.IsExternalRefsAllowed = true
 
+	if loader.config.Authorization != "" {
+		headers, err := loader.config.Headers()
+		if err != nil {
+			return nil, err
+		}
+
+		setTransportWithHeaders(headers)
+	}
+
 	u, err := url.Parse(loader.config.SwaggerAddr)
 	if err != nil {
 		return nil, err
@@ -26,4 +36,20 @@ func (loader *Loader) Load() (*openapi3.Swagger, error) {
 	}
 
 	return swaggerLoader.LoadSwaggerFromFile(loader.config.SwaggerAddr)
+}
+
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func setTransportWithHeaders(headers http.Header) {
+	http.DefaultClient.Transport = RoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		for key, value := range headers {
+			request.Header[key] = value
+		}
+
+		return http.DefaultTransport.RoundTrip(request)
+	})
 }


### PR DESCRIPTION
Provided flag --authorization(-a) which adds provided headers when fetching the OpenAPI definitions remotely.