### PR TITLE
Add version display functionality to main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"reflect"
+	"runtime/debug"
 
 	"github.com/goioc/di"
 
@@ -13,7 +16,55 @@ import (
 	"github.com/mikekonan/go-oas3/writer"
 )
 
+func getVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	
+	// Get module version
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	
+	// Fallback to VCS revision if available
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			if len(setting.Value) >= 7 {
+				return "dev-" + setting.Value[:7]
+			}
+			return "dev-" + setting.Value
+		}
+	}
+	
+	return "development"
+}
+
 func main() {
+	// Check for version flag before confita processes flags
+	for _, arg := range os.Args[1:] {
+		if arg == "-version" || arg == "--version" {
+			fmt.Printf("go-oas3 version %s\n", getVersion())
+			
+			// Print additional build info
+			if info, ok := debug.ReadBuildInfo(); ok {
+				fmt.Printf("Go version: %s\n", info.GoVersion)
+				for _, setting := range info.Settings {
+					switch setting.Key {
+					case "vcs.revision":
+						fmt.Printf("Git commit: %s\n", setting.Value)
+					case "vcs.time":
+						fmt.Printf("Build time: %s\n", setting.Value)
+					case "vcs.modified":
+						if setting.Value == "true" {
+							fmt.Printf("Modified: true (development build)\n")
+						}
+					}
+				}
+			}
+			os.Exit(0)
+		}
+	}
 	di.RegisterBeanInstance("config", new(configurator.Config).Defaults())
 	di.RegisterBean("loader", reflect.TypeOf((*loader.Loader)(nil)))
 	di.RegisterBean("configurator", reflect.TypeOf((*configurator.Configurator)(nil)))


### PR DESCRIPTION
- Implemented getVersion() function to retrieve module version and build info
- Added --version and -version flag handling to display version information
- Shows Go version, Git commit, build time, and modification status
- Imported necessary packages: fmt, os, runtime/debug

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added command-line version reporting. Using -version or --version now prints the application’s semantic version (or development identifier), along with build metadata including Go runtime version, Git commit, build time, and whether the build contains local modifications. The program exits immediately after displaying this information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->